### PR TITLE
Add no-useless-fragment-rule

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -13,6 +13,7 @@ module.exports = {
         'jsx-quotes': ['error', 'prefer-double'],
         'react/jsx-indent': ['error', 4],
         'react/jsx-indent-props': ['error', 4],
+        'react/jsx-no-useless-fragment': 'error',
         'react/jsx-props-no-spreading': 'off',
         'react/require-default-props': 'off',
     },

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -5,5 +5,8 @@
   "dependencies": {
     "@thetribe/eslint-config": "^0.2.1",
     "eslint-config-airbnb": "^18.0.1"
+  },
+  "peerDependencies": {
+    "eslint-plugin-react": "^7.15.0"
   }
 }


### PR DESCRIPTION
Prevent creating fragments with only one child or passing fragments as children of html elements.