### PR TITLE
Disable react/jsx-one-expression-per-line rule

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -14,6 +14,7 @@ module.exports = {
         'react/jsx-indent': ['error', 4],
         'react/jsx-indent-props': ['error', 4],
         'react/jsx-no-useless-fragment': 'error',
+        'react/jsx-one-expression-per-line': 'off',
         'react/jsx-props-no-spreading': 'off',
         'react/jsx-sort-default-props': 'error',
         'react/jsx-sort-props': ['error', {


### PR DESCRIPTION
Disable `react/jsx-on-expression-per-line` to allow expressions like this: https://github.com/thetribeio/node-react-starter-kit/blob/a6ef8dcd458223adae172e15e8a22e93fea19ada/app/components/BookList.jsx#L17 instead of forcing to either split the text into multiple lines or use a template literal.