### PR TITLE
Disable class-methods-use-this rule

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -2,6 +2,7 @@ module.exports = {
     extends: 'airbnb-base',
     rules: {
         'arrow-parens': ['error', 'always'],
+        'class-methods-use-this': 'off',
         curly: ['error', 'all'],
         'import/order': ['error', {
             alphabetize: {


### PR DESCRIPTION
There are valid use cases for creating a class method that uses this like when you want to respect a contract or when inheritance is involved.