### PR TITLE
Replace default-case rule with switch-exhaustiveness-check

### DIFF
--- a/packages/eslint-config-react-typescript/README.md
+++ b/packages/eslint-config-react-typescript/README.md
@@ -13,6 +13,9 @@ yarn add --dev @thetribe/eslint-config-react-typescript @typescript-eslint/eslin
 
 {
     "root": true,
-    "extends": "@thetribe/eslint-config-react-typescript"
+    "extends": "@thetribe/eslint-config-react-typescript",
+    "parserOptions": {
+        "project": "./tsconfig.json"
+    }
 }
 ```

--- a/packages/eslint-config-typescript/README.md
+++ b/packages/eslint-config-typescript/README.md
@@ -13,6 +13,9 @@ yarn add --dev @thetribe/eslint-config-typescript @typescript-eslint/eslint-plug
 
 {
     "root": true,
-    "extends": "@thetribe/eslint-config-typescript"
+    "extends": "@thetribe/eslint-config-typescript",
+    "parserOptions": {
+        "project": "./tsconfig.json"
+    }
 }
 ```

--- a/packages/eslint-config-typescript/index.js
+++ b/packages/eslint-config-typescript/index.js
@@ -22,6 +22,9 @@ module.exports = {
             mjs: 'never',
             ts: 'never',
         }],
+        // Replace default-case with switch-exhaustiveness-check
+        '@typescript-eslint/switch-exhaustiveness-check': 'error',
+        'default-case': 'off',
     },
     settings: {
         'import/extensions': [


### PR DESCRIPTION
Use typescript-eslint switch-exhaustiveness-check since it's more powerfull than the default-case rule.